### PR TITLE
Add CLI shell

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/urfave/cli"
+)
+
+func main() {
+	app := &cli.App{
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "doc",
+				Aliases:  []string{"d"},
+				Usage:    "Generates a document of type `DOCUMENT`",
+				Required: true,
+			},
+		},
+		Name:    "gendoc",
+		Version: "v0.1",
+		Usage:   "Generate fake documents for development purposes",
+		Action: func(c *cli.Context) error {
+			fmt.Println(c.String("doc"))
+			return nil
+		},
+	}
+
+	err := app.Run(os.Args)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds a simple CLI shell on main using https://github.com/urfave/cli package.

The -d flag will tell the type of document to be generated, the first document will be implemented soon.

I don't know yet how to test the main() function, something tells me that unit testing this is not appropiate, further studies are required.